### PR TITLE
split compose ui tooling deps

### DIFF
--- a/features/player/build.gradle.kts
+++ b/features/player/build.gradle.kts
@@ -47,5 +47,7 @@ dependencies {
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.coil.compose)
     implementation(libs.coil.network.okhttp)
-    debugImplementation(libs.androidx.compose.ui.tooling.preview)
+
+    debugImplementation(libs.androidx.compose.ui.tooling)
+    implementation(libs.androidx.compose.ui.tooling.preview)
 }

--- a/features/search/build.gradle.kts
+++ b/features/search/build.gradle.kts
@@ -45,5 +45,7 @@ dependencies {
     implementation(libs.androidx.compose.runtime)
     implementation(libs.coil.compose)
     implementation(libs.coil.network.okhttp)
-    debugImplementation(libs.androidx.compose.ui.tooling.preview)
+
+    debugImplementation(libs.androidx.compose.ui.tooling)
+    implementation(libs.androidx.compose.ui.tooling.preview)
 }


### PR DESCRIPTION
Use the debug implementation for ui.tooling which actually helps in rendering within Android Studio.

The ui.tooling.preview can be regular implementation as it is meant for using Preview annotation in all flavours and will be removed for release builds anyways.