### PR TITLE
Fix playback continuing during phone call

### DIFF
--- a/app/src/main/java/dev/crazo7924/onlymusic/service/PlayerService.kt
+++ b/app/src/main/java/dev/crazo7924/onlymusic/service/PlayerService.kt
@@ -11,6 +11,7 @@ import android.os.Bundle
 import android.util.Log
 import androidx.annotation.OptIn
 import androidx.core.app.TaskStackBuilder
+import androidx.media3.common.AudioAttributes
 import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.util.UnstableApi
@@ -78,7 +79,17 @@ class PlayerService : MediaSessionService() {
 
     override fun onCreate() {
         super.onCreate()
-        exoPlayer = ExoPlayer.Builder(this).build()
+
+        val audioAttributes = AudioAttributes.Builder()
+            .setUsage(C.USAGE_MEDIA)
+            .setContentType(C.AUDIO_CONTENT_TYPE_MUSIC)
+            .build()
+
+        exoPlayer = ExoPlayer.Builder(this)
+            .setAudioAttributes(audioAttributes, true)
+            .setHandleAudioBecomingNoisy(true)
+            .build()
+
         musicRepository = NewPipeMusicRepository() // Replace with DI if available
 
         mediaSessionCallback = PlayerMediaSessionCallback()


### PR DESCRIPTION
Configures ExoPlayer to automatically manage audio focus via AudioAttributes. This pauses playback on interruptions such as incoming phone calls. Additionally, enables handling of audio becoming noisy to pause playback when headphones are disconnected.

Fixes #19