### PR TITLE
Add acra crash dialog

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -54,6 +54,7 @@ extensions.configure<ApplicationExtension>("android") {
 
     buildFeatures {
         compose = true
+        buildConfig = true
     }
 
     testOptions {
@@ -88,6 +89,9 @@ dependencies {
     implementation(libs.androidx.compose.material.icons.extended)
     implementation(libs.coil.compose)
     implementation(libs.coil.network.okhttp)
+
+    implementation(libs.acra.core)
+    implementation(libs.acra.dialog)
 
     coreLibraryDesugaring(libs.desugar.jdk.libs.nio)
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
         tools:ignore="ForegroundServicesPolicy" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
     <application
+        android:name=".OnlyMusicApplication"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
@@ -42,6 +43,14 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <activity
+            android:name=".CrashDialogActivity"
+            android:process=":acra"
+            android:excludeFromRecents="true"
+            android:finishOnTaskLaunch="true"
+            android:launchMode="singleInstance"
+            android:theme="@style/Theme.OnlyMusic"/>
     </application>
 
 </manifest>

--- a/app/src/main/java/dev/crazo7924/onlymusic/CrashDialogActivity.kt
+++ b/app/src/main/java/dev/crazo7924/onlymusic/CrashDialogActivity.kt
@@ -1,0 +1,48 @@
+package dev.crazo7924.onlymusic
+
+import android.os.Bundle
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import org.acra.dialog.CrashReportDialogHelper
+import androidx.activity.ComponentActivity
+
+class CrashDialogActivity : ComponentActivity() {
+
+    private lateinit var helper: CrashReportDialogHelper
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        helper = CrashReportDialogHelper(this, intent)
+        val stackTrace = helper.reportData?.getString(org.acra.ReportField.STACK_TRACE) ?: "Unknown error occurred"
+
+        setContent {
+            MaterialTheme {
+                Surface(modifier = Modifier.fillMaxSize()) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(16.dp)
+                            .verticalScroll(rememberScrollState())
+                    ) {
+                        Text(
+                            text = "Crash Report",
+                            style = MaterialTheme.typography.headlineMedium,
+                            modifier = Modifier.padding(bottom = 8.dp)
+                        )
+                        Text(text = stackTrace)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/dev/crazo7924/onlymusic/OnlyMusicApplication.kt
+++ b/app/src/main/java/dev/crazo7924/onlymusic/OnlyMusicApplication.kt
@@ -1,0 +1,23 @@
+package dev.crazo7924.onlymusic
+
+import android.app.Application
+import android.content.Context
+import org.acra.config.dialog
+import org.acra.ktx.initAcra
+
+class OnlyMusicApplication : Application() {
+    override fun attachBaseContext(base: Context) {
+        super.attachBaseContext(base)
+
+        initAcra {
+            buildConfigClass = BuildConfig::class.java
+            reportFormat = org.acra.data.StringFormat.JSON
+
+            dialog {
+                text = "The application crashed."
+                title = "Crash"
+                reportDialogClass = CrashDialogActivity::class.java
+            }
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,7 @@ newpipeExtractor = "v0.26.2"
 
 # Tooling
 desugarJdkLibs = "2.1.5"
+acra = "5.13.1"
 
 # Testing
 junit4 = "4.13.2"
@@ -74,6 +75,10 @@ androidx-core-testing = { group = "androidx.arch.core", name = "core-testing", v
 # Testing - Instrumentation
 androidx-junit-ktx = { group = "androidx.test.ext", name = "junit-ktx", version.ref = "androidxJunit" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espresso" }
+
+# ACRA
+acra-core = { group = "ch.acra", name = "acra-core", version.ref = "acra" }
+acra-dialog = { group = "ch.acra", name = "acra-dialog", version.ref = "acra" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
This PR integrates the ACRA library for displaying crash messages directly on the device using a dialog, as requested. 

It accomplishes the following:
1. Adds `acra-core` and `acra-dialog` dependencies.
2. Creates `OnlyMusicApplication` to initialize ACRA in the `attachBaseContext` method, setting it up to launch a custom dialog when a crash occurs.
3. Implements `CrashDialogActivity`, a custom Activity that extends `ComponentActivity` and uses `CrashReportDialogHelper` to fetch the crash stack trace and displays it in a scrollable Compose view.
4. Updates `AndroidManifest.xml` to include the application class and the newly created `CrashDialogActivity`.

---
*PR created automatically by Jules for task [8112808795581976102](https://jules.google.com/task/8112808795581976102) started by @crazo7924*