### PR TITLE
feat: Implement auto-loading next pages in queue

### DIFF
--- a/app/src/main/java/dev/crazo7924/onlymusic/service/PlayerService.kt
+++ b/app/src/main/java/dev/crazo7924/onlymusic/service/PlayerService.kt
@@ -58,6 +58,9 @@ class PlayerService : MediaSessionService() {
         val COMMAND_ENQUEUE_RADIO =
             SessionCommand("dev.crazo7924.onlymusic.player.START_RADIO", Bundle.EMPTY)
 
+        val COMMAND_LOAD_MORE_QUEUE =
+            SessionCommand("dev.crazo7924.onlymusic.player.LOAD_MORE_QUEUE", Bundle.EMPTY)
+
         // Keys for Bundle arguments
         const val KEY_URI = "KEY_URI"
         const val KEY_PLAYLIST_URI = "KEY_PLAYLIST_URI"
@@ -148,6 +151,34 @@ class PlayerService : MediaSessionService() {
     }
 
     private inner class PlayerMediaSessionCallback : MediaSession.Callback {
+
+        private var isFetchingMore = false
+
+        fun processLoadMoreQueue() {
+            if (isFetchingMore) return
+            isFetchingMore = true
+            serviceScope.launch {
+                Log.d(TAG, "Fetching more items for queue...")
+                val resultFlow = musicRepository.loadMorePlaylistItems()
+                var addedCount = 0
+                resultFlow.collect { result ->
+                    result.onSuccess { item ->
+                        withContext(Dispatchers.Main) {
+                            exoPlayer.addMediaItem(item.toMediaItem())
+                            addedCount++
+                        }
+                    }.onFailure { error ->
+                        Log.e(TAG, "Error fetching more items: $error")
+                    }
+                }
+                if (addedCount > 0) {
+                    Log.d(TAG, "Added $addedCount more items to queue.")
+                } else {
+                    Log.d(TAG, "No more items to fetch.")
+                }
+                isFetchingMore = false
+            }
+        }
 
         fun processLoadStreamUri(uri: String, playWhenReady: Boolean) {
             serviceScope.launch {
@@ -283,6 +314,7 @@ class PlayerService : MediaSessionService() {
                 .add(COMMAND_ENQUEUE_PLAYLIST_URI)
                 .add(COMMAND_SEEK_TO_PERCENTAGE)
                 .add(COMMAND_ENQUEUE_RADIO)
+                .add(COMMAND_LOAD_MORE_QUEUE)
                 .build()
 
             return MediaSession.ConnectionResult.AcceptedResultBuilder(session)
@@ -358,6 +390,11 @@ class PlayerService : MediaSessionService() {
                         processEnqueueRadio(mediaUri)
                         return Futures.immediateFuture(SessionResult(SessionResult.RESULT_SUCCESS))
                     }
+                }
+
+                COMMAND_LOAD_MORE_QUEUE -> {
+                    processLoadMoreQueue()
+                    return Futures.immediateFuture(SessionResult(SessionResult.RESULT_SUCCESS))
                 }
             }
             return Futures.immediateFuture(SessionResult(SessionError.ERROR_UNKNOWN)) // Or specific error

--- a/app/src/main/java/dev/crazo7924/onlymusic/ui/main/MainScreen.kt
+++ b/app/src/main/java/dev/crazo7924/onlymusic/ui/main/MainScreen.kt
@@ -245,6 +245,10 @@ fun MainScreen(
                                     val controller = mediaControllerManager.getController()
                                     controller?.seekToDefaultPosition(index)
                                     controller?.play() // Optional: start playing selected item
+                                },
+                                onLoadMore = {
+                                    val controller = mediaControllerManager.getController()
+                                    controller?.sendCustomCommand(PlayerService.COMMAND_LOAD_MORE_QUEUE, Bundle.EMPTY)
                                 })
                         }
                     }

--- a/data/src/main/java/dev/crazo7924/onlymusic/data/repository/LocalMusicRepository.kt
+++ b/data/src/main/java/dev/crazo7924/onlymusic/data/repository/LocalMusicRepository.kt
@@ -36,6 +36,15 @@ class LocalMusicRepository(private val playlistDao: PlaylistDao) : MusicReposito
         ))
         }.flowOn(Dispatchers.IO)
 
+    override suspend fun loadMorePlaylistItems(): Flow<Result<MediaListItem>> =
+        flow<Result<MediaListItem>> {
+            emit(
+                Result.failure(
+                    Exception("App is in offline mode")
+                )
+            )
+        }.flowOn(Dispatchers.IO)
+
     override suspend fun search(query: String): Flow<Result<MediaListItem>> =
         flow<Result<MediaListItem>> {
             playlistDao.getLikedSongs()?.songs?.forEach {

--- a/data/src/main/java/dev/crazo7924/onlymusic/data/repository/MusicRepository.kt
+++ b/data/src/main/java/dev/crazo7924/onlymusic/data/repository/MusicRepository.kt
@@ -13,5 +13,6 @@ interface MusicRepository {
     suspend fun loadPlaylistUri(uri: String?): Flow<Result<MediaListItem>>
 
     suspend fun loadAutoPlaylistUri(uri: String?): Flow<Result<MediaListItem>>
+    suspend fun loadMorePlaylistItems(): Flow<Result<MediaListItem>>
     suspend fun search(query: String): Flow<Result<MediaListItem>>
 }

--- a/data/src/main/java/dev/crazo7924/onlymusic/data/repository/NewPipeMusicRepository.kt
+++ b/data/src/main/java/dev/crazo7924/onlymusic/data/repository/NewPipeMusicRepository.kt
@@ -21,6 +21,9 @@ import org.schabi.newpipe.extractor.InfoItem.InfoType
 import org.schabi.newpipe.extractor.NewPipe
 import org.schabi.newpipe.extractor.ServiceList
 import org.schabi.newpipe.extractor.services.youtube.YoutubeParsingHelper
+import org.schabi.newpipe.extractor.Page
+import org.schabi.newpipe.extractor.ListExtractor
+import org.schabi.newpipe.extractor.InfoItem
 import org.schabi.newpipe.extractor.services.youtube.extractors.YoutubeMixPlaylistExtractor
 import org.schabi.newpipe.extractor.services.youtube.extractors.YoutubeMusicSearchExtractor
 import org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubePlaylistLinkHandlerFactory
@@ -29,6 +32,9 @@ import org.schabi.newpipe.extractor.services.youtube.linkHandler.YoutubeSearchQu
 import org.schabi.newpipe.extractor.stream.StreamInfoItem
 
 class NewPipeMusicRepository : MusicRepository {
+
+    private var currentExtractor: ListExtractor<out InfoItem>? = null
+    private var currentPage: ListExtractor.InfoItemsPage<out InfoItem>? = null
 
     init {
         NewPipe.init(DownloaderImpl)
@@ -128,6 +134,8 @@ class NewPipeMusicRepository : MusicRepository {
         val outcome = runCatching { playListExtractor.fetchPage() }
 
         outcome.onSuccess {
+            currentExtractor = playListExtractor
+            currentPage = playListExtractor.initialPage
 
             playListExtractor?.initialPage?.items?.chunked(5)?.forEach { batch ->
                 coroutineScope {
@@ -169,7 +177,37 @@ class NewPipeMusicRepository : MusicRepository {
                 return@flow
             }
 
+            currentExtractor = playListExtractor
+            currentPage = playListExtractor.initialPage
+
             playListExtractor.initialPage.items.chunked(5).forEach { batch ->
+                coroutineScope {
+                    val deferredResults = batch.map { item ->
+                        async { loadMediaUri(item.url) }
+                    }
+                    deferredResults.awaitAll().forEach { result ->
+                        emit(result)
+                    }
+                }
+            }
+        }.flowOn(Dispatchers.IO)
+
+    override suspend fun loadMorePlaylistItems(): Flow<Result<MediaListItem>> =
+        flow {
+            val extractor = currentExtractor ?: return@flow
+            val page = currentPage ?: return@flow
+
+            if (!page.hasNextPage()) return@flow
+
+            val outcome = runCatching { extractor.getPage(page.nextPage) }
+            val nextPage = outcome.getOrElse {
+                it.printStackTrace()
+                return@flow
+            }
+
+            currentPage = nextPage
+
+            nextPage.items.chunked(5).forEach { batch ->
                 coroutineScope {
                     val deferredResults = batch.map { item ->
                         async { loadMediaUri(item.url) }

--- a/features/player/src/main/java/dev/crazo7924/onlymusic/features/player/ui/QueueUI.kt
+++ b/features/player/src/main/java/dev/crazo7924/onlymusic/features/player/ui/QueueUI.kt
@@ -13,12 +13,16 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.foundation.border
@@ -42,7 +46,7 @@ import org.schabi.newpipe.extractor.InfoItem
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun QueueUI(items: List<MediaListItem>, currentIndex: Int, onItemClicked: (Int) -> Unit) {
+fun QueueUI(items: List<MediaListItem>, currentIndex: Int, onItemClicked: (Int) -> Unit, onLoadMore: () -> Unit = {}) {
     Scaffold(
         topBar = {
             TopAppBar(
@@ -58,6 +62,7 @@ fun QueueUI(items: List<MediaListItem>, currentIndex: Int, onItemClicked: (Int) 
             onItemClicked = { index ->
                 onItemClicked(index)
             },
+            onLoadMore = onLoadMore
         )
     }
 }
@@ -68,9 +73,25 @@ fun QueueList(
     mediaItems: List<MediaListItem>,
     currentIndex: Int,
     onItemClicked: (Int) -> Unit,
+    onLoadMore: () -> Unit = {}
 ) {
+    val listState = rememberLazyListState()
 
-    LazyColumn(modifier = modifier) {
+    val shouldLoadMore = remember {
+        derivedStateOf {
+            val lastVisibleItemIndex = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index
+            val totalItemsCount = listState.layoutInfo.totalItemsCount
+            lastVisibleItemIndex != null && lastVisibleItemIndex >= totalItemsCount - 5
+        }
+    }
+
+    LaunchedEffect(shouldLoadMore.value) {
+        if (shouldLoadMore.value) {
+            onLoadMore()
+        }
+    }
+
+    LazyColumn(modifier = modifier, state = listState) {
         items(count = mediaItems.size) { index ->
             val isPlaying = index == currentIndex
             val isPlayed = index < currentIndex


### PR DESCRIPTION
Implement getting next pages with available methods for playlistextractor and load while scrolling near the end of the queue. Details are available in issue 1.

---
*PR created automatically by Jules for task [11033724356273145073](https://jules.google.com/task/11033724356273145073) started by @crazo7924*