### PR TITLE
Store artist data in room database

### DIFF
--- a/data/schemas/dev.crazo7924.onlymusic.data.db.OnlyMusicDatabase/2.json
+++ b/data/schemas/dev.crazo7924.onlymusic.data.db.OnlyMusicDatabase/2.json
@@ -1,0 +1,185 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 2,
+    "identityHash": "88cb7f92c7e2ffc53351b2e4fd0c8fb2",
+    "entities": [
+      {
+        "tableName": "Playlist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlistId` TEXT NOT NULL, `name` TEXT NOT NULL, `uri` TEXT, `playlistType` TEXT NOT NULL, PRIMARY KEY(`playlistId`))",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uri",
+            "columnName": "uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "playlistType",
+            "columnName": "playlistType",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlistId"
+          ]
+        }
+      },
+      {
+        "tableName": "Song",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`songId` TEXT NOT NULL, `title` TEXT NOT NULL, `uri` TEXT NOT NULL, `artworkUri` TEXT, `duration` INTEGER NOT NULL, PRIMARY KEY(`songId`))",
+        "fields": [
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "uri",
+            "columnName": "uri",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artworkUri",
+            "columnName": "artworkUri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "songId"
+          ]
+        }
+      },
+      {
+        "tableName": "Artist",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`artistId` TEXT NOT NULL, `name` TEXT NOT NULL, PRIMARY KEY(`artistId`))",
+        "fields": [
+          {
+            "fieldPath": "artistId",
+            "columnName": "artistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "artistId"
+          ]
+        }
+      },
+      {
+        "tableName": "PlaylistSongsCrossRef",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`playlistId` TEXT NOT NULL, `songId` TEXT NOT NULL, PRIMARY KEY(`playlistId`, `songId`))",
+        "fields": [
+          {
+            "fieldPath": "playlistId",
+            "columnName": "playlistId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "playlistId",
+            "songId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_PlaylistSongsCrossRef_songId",
+            "unique": false,
+            "columnNames": [
+              "songId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_PlaylistSongsCrossRef_songId` ON `${TABLE_NAME}` (`songId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "SongArtistCrossRef",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`songId` TEXT NOT NULL, `artistId` TEXT NOT NULL, PRIMARY KEY(`songId`, `artistId`))",
+        "fields": [
+          {
+            "fieldPath": "songId",
+            "columnName": "songId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "artistId",
+            "columnName": "artistId",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "songId",
+            "artistId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_SongArtistCrossRef_artistId",
+            "unique": false,
+            "columnNames": [
+              "artistId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_SongArtistCrossRef_artistId` ON `${TABLE_NAME}` (`artistId`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '88cb7f92c7e2ffc53351b2e4fd0c8fb2')"
+    ]
+  }
+}

--- a/data/src/main/java/dev/crazo7924/onlymusic/data/db/ArtistDao.kt
+++ b/data/src/main/java/dev/crazo7924/onlymusic/data/db/ArtistDao.kt
@@ -1,0 +1,23 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 Bharat Dev Burman
+ */
+
+package dev.crazo7924.onlymusic.data.db
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+
+@Dao
+interface ArtistDao {
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insertArtist(artist: Artist)
+
+    @Query("SELECT * FROM Artist WHERE name = :name LIMIT 1")
+    suspend fun getArtistByName(name: String): Artist?
+
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    suspend fun insertSongArtistCrossRef(crossRef: SongArtistCrossRef)
+}

--- a/data/src/main/java/dev/crazo7924/onlymusic/data/db/OnlyMusicDatabase.kt
+++ b/data/src/main/java/dev/crazo7924/onlymusic/data/db/OnlyMusicDatabase.kt
@@ -14,19 +14,21 @@ import java.net.URI
 import java.util.UUID
 
 @Database(
-    version = 1,
+    version = 2,
     exportSchema = true,
     entities = [
         Playlist::class,
         Song::class,
         Artist::class,
-        PlaylistSongsCrossRef::class
+        PlaylistSongsCrossRef::class,
+        SongArtistCrossRef::class
     ]
 )
 @TypeConverters(Converters::class)
 abstract class OnlyMusicDatabase : RoomDatabase() {
     abstract fun playlistDao(): PlaylistDao
     abstract fun songDao(): SongDao
+    abstract fun artistDao(): ArtistDao
 }
 
 val initPlaylistCallback = object : RoomDatabase.Callback() {

--- a/data/src/main/java/dev/crazo7924/onlymusic/data/db/SongArtistCrossRef.kt
+++ b/data/src/main/java/dev/crazo7924/onlymusic/data/db/SongArtistCrossRef.kt
@@ -1,0 +1,19 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 Bharat Dev Burman
+ */
+
+package dev.crazo7924.onlymusic.data.db
+
+import androidx.room.Entity
+import androidx.room.Index
+import java.util.UUID
+
+@Entity(
+    primaryKeys = ["songId", "artistId"],
+    indices = [Index(value = ["artistId"])]
+)
+data class SongArtistCrossRef(
+    val songId: String,
+    val artistId: UUID,
+)

--- a/data/src/main/java/dev/crazo7924/onlymusic/data/db/SongWithArtists.kt
+++ b/data/src/main/java/dev/crazo7924/onlymusic/data/db/SongWithArtists.kt
@@ -6,13 +6,15 @@
 package dev.crazo7924.onlymusic.data.db
 
 import androidx.room.Embedded
+import androidx.room.Junction
 import androidx.room.Relation
 
 data class SongWithArtists(
     @Embedded val song: Song,
     @Relation(
         parentColumn = "songId",
-        entityColumn = "artistId"
+        entityColumn = "artistId",
+        associateBy = Junction(SongArtistCrossRef::class)
     )
     val artists: List<Artist>
 )

--- a/data/src/main/java/dev/crazo7924/onlymusic/data/di/DatabaseModule.kt
+++ b/data/src/main/java/dev/crazo7924/onlymusic/data/di/DatabaseModule.kt
@@ -7,11 +7,14 @@ package dev.crazo7924.onlymusic.data.di
 
 import android.content.Context
 import androidx.room.Room
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
+import dev.crazo7924.onlymusic.data.db.ArtistDao
 import dev.crazo7924.onlymusic.data.db.OnlyMusicDatabase
 import dev.crazo7924.onlymusic.data.db.PlaylistDao
 import dev.crazo7924.onlymusic.data.db.SongDao
@@ -25,11 +28,24 @@ object DatabaseModule {
     @Provides
     @Singleton
     fun provideDatabase(@ApplicationContext context: Context): OnlyMusicDatabase {
+        val MIGRATION_1_2 = object : Migration(1, 2) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL(
+                    "CREATE TABLE IF NOT EXISTS `SongArtistCrossRef` (`songId` TEXT NOT NULL, `artistId` TEXT NOT NULL, PRIMARY KEY(`songId`, `artistId`))"
+                )
+                db.execSQL(
+                    "CREATE INDEX IF NOT EXISTS `index_SongArtistCrossRef_artistId` ON `SongArtistCrossRef` (`artistId`)"
+                )
+            }
+        }
+
         return Room.databaseBuilder(
             context,
             OnlyMusicDatabase::class.java, "only-music-database"
         )
             .addCallback(initPlaylistCallback)
+            .addMigrations(MIGRATION_1_2)
+            .fallbackToDestructiveMigration(dropAllTables = false)
             .build()
     }
 
@@ -41,5 +57,10 @@ object DatabaseModule {
     @Provides
     fun provideSongDao(database: OnlyMusicDatabase): SongDao {
         return database.songDao()
+    }
+
+    @Provides
+    fun provideArtistDao(database: OnlyMusicDatabase): ArtistDao {
+        return database.artistDao()
     }
 }

--- a/data/src/main/java/dev/crazo7924/onlymusic/data/repository/CachingMusicRepository.kt
+++ b/data/src/main/java/dev/crazo7924/onlymusic/data/repository/CachingMusicRepository.kt
@@ -7,9 +7,12 @@ package dev.crazo7924.onlymusic.data.repository
 
 import android.util.Log
 import dev.crazo7924.onlymusic.core.MediaListItem
+import dev.crazo7924.onlymusic.data.db.Artist
+import dev.crazo7924.onlymusic.data.db.ArtistDao
 import dev.crazo7924.onlymusic.data.db.PlaylistDao
 import dev.crazo7924.onlymusic.data.db.PlaylistSongsCrossRef
 import dev.crazo7924.onlymusic.data.db.Song
+import dev.crazo7924.onlymusic.data.db.SongArtistCrossRef
 import dev.crazo7924.onlymusic.data.db.SongDao
 import dev.crazo7924.onlymusic.data.di.RemoteRepository
 import dev.crazo7924.onlymusic.data.toMediaListItem
@@ -24,6 +27,7 @@ class CachingMusicRepository @Inject constructor(
     @param:RemoteRepository private val remoteRepository: MusicRepository,
     private val playlistDao: PlaylistDao,
     private val songDao: SongDao,
+    private val artistDao: ArtistDao,
 ) : MusicRepository by remoteRepository {
 
     override suspend fun search(query: String): Flow<Result<MediaListItem>> = flow {
@@ -43,6 +47,20 @@ class CachingMusicRepository @Inject constructor(
                     duration = mediaListItem.duration ?: 0L
                 )
                 songDao.insertSong(song)
+
+                mediaListItem.artist?.let { artistName ->
+                    var artist = artistDao.getArtistByName(artistName)
+                    if (artist == null) {
+                        artist = Artist(name = artistName)
+                        artistDao.insertArtist(artist)
+                    }
+                    artistDao.insertSongArtistCrossRef(
+                        SongArtistCrossRef(
+                            songId = song.songId,
+                            artistId = artist.artistId
+                        )
+                    )
+                }
 
                 playlistDao.insertSongToPlaylist(
                     PlaylistSongsCrossRef(

--- a/data/src/test/java/dev/crazo7924/onlymusic/data/repository/CachingMusicRepositoryTest.kt
+++ b/data/src/test/java/dev/crazo7924/onlymusic/data/repository/CachingMusicRepositoryTest.kt
@@ -8,6 +8,7 @@ import dev.crazo7924.onlymusic.data.db.PlaylistWithSongs
 import dev.crazo7924.onlymusic.data.db.Song
 import dev.crazo7924.onlymusic.data.db.SongWithArtists
 import dev.crazo7924.onlymusic.data.db.SongDao
+import dev.crazo7924.onlymusic.data.db.ArtistDao
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
@@ -30,10 +31,11 @@ class CachingMusicRepositoryTest {
     private val remoteRepository: MusicRepository = mockk()
     private val playlistDao: PlaylistDao = mockk(relaxed = true)
     private val songDao: SongDao = mockk(relaxed = true)
+    private val artistDao: ArtistDao = mockk(relaxed = true)
 
     @Before
     fun setup() {
-        repository = CachingMusicRepository(remoteRepository, playlistDao, songDao)
+        repository = CachingMusicRepository(remoteRepository, playlistDao, songDao, artistDao)
     }
 
     @Test


### PR DESCRIPTION
- Create `SongArtistCrossRef` entity to map many-to-many relationship between Song and Artist
- Update `SongWithArtists` relation to utilize the junction table
- Create `ArtistDao` for insert and retrieve operations
- Configure Room Database schema version from 1 to 2
- Include `Migration` script in `DatabaseModule`
- Add logic in `CachingMusicRepository` to save artist data into DB when caching remote results